### PR TITLE
Get gcloud shell completions path from gcloud tool

### DIFF
--- a/.zsh-local-mac
+++ b/.zsh-local-mac
@@ -29,7 +29,8 @@ if [ -f '/Users/davidhaley/apps/google-cloud-sdk/path.zsh.inc' ]; then . '/Users
 #}
 
 # The next line enables shell command completion for gcloud.
-if [ -f '/Users/davidhaley/apps/google-cloud-sdk/completion.zsh.inc' ]; then . '/Users/davidhaley/apps/google-cloud-sdk/completion.zsh.inc'; fi
+gcloud_root=`gcloud info --format="value(installation.sdk_root)"`
+if [ -f "$gcloud_root/completion.zsh.inc" ]; then source "$gcloud_root/completion.zsh.inc"; fi
 
 export NVM_DIR="$HOME/.nvm"
 alias load-nvm='[ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"'  # This loads nvm

--- a/.zsh-local-mac
+++ b/.zsh-local-mac
@@ -68,6 +68,10 @@ fi
 
 export GROOVY_HOME=/opt/homebrew/opt/groovy/libexec
 
+export CBLOSC_LIB=$(echo $(brew --cellar c-blosc)/*/lib)
+export DYLD_LIBRARY_PATH="$CBLOSC_LIB"
+export JAVA_OPTS="-Djna.library.path=$CBLOSC_LIB"
+
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
 # Add RVM to PATH for scripting. Make sure this is the last PATH variable change.

--- a/.zsh-local-mac
+++ b/.zsh-local-mac
@@ -68,6 +68,8 @@ fi
 
 export GROOVY_HOME=/opt/homebrew/opt/groovy/libexec
 
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
 # Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
 export PATH="$PATH:$HOME/.rvm/bin"
 


### PR DESCRIPTION
Use gcloud to get its SDK root for shell completions rather than use a hard-coded path.

Also add some CBLOSC settings used when using cblosc in the QuPath ZARR extension.